### PR TITLE
サイドバーに情報を追加

### DIFF
--- a/app/assets/stylesheets/style.css
+++ b/app/assets/stylesheets/style.css
@@ -869,24 +869,50 @@ footer p {
   width: 30vw;
   height: auto;
 }
+/* ヘッダー */
 .left-header {
   height: 100px;
   padding: 0 15px;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  background-color: yellowgreen;
 }
-
-.left-lists {
-  height: calc(100vh - 100px);
-  padding: 0 15px;
-}
-
-.room {
+/* ボタン部品 */
+.user-nickname {
+  font-size: 20px;
+  color: #666;
   text-decoration: none;
 }
+
+.user-signout-btn {
+  font-size: 15px;
+  border: 1px solid darkolivegreen;
+  color: #666;
+  text-decoration: none;
+  padding: 15px;
+}
+
+.user-signin-btn,.user-signup-btn {
+  font-size: 15px;
+  border: 1px solid darkolivegreen;
+  color: #666;
+  text-decoration: none;
+  padding: 15px;
+}
+.left-lists {
+  background-color: wheat;
+  height: calc(100vh - 100px);
+  padding: 0 15px;
+  overflow: scroll;
+}
+
+.room, .follow-num, .info, .info2 {
+  padding: 20px 0 40px;
+}
 .room-name {
-  font-size: large;
+  text-decoration: none;
+  color: darkolivegreen;
 }
 
 /* main */

--- a/app/views/calendars/_left.html.erb
+++ b/app/views/calendars/_left.html.erb
@@ -1,12 +1,41 @@
 <div class="left-header">
+  <% if user_signed_in? %>
+    <div class="user-nickname">
+      <%= current_user.nickname %>
+    </div>
+    <div class="user-signout-btn">
+      <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
+    </div>
+  <% else %>
+    <div class="user-signin-btn">
+      <%= link_to "ログイン", new_user_session_path, class: "post" %>
+    </div>
+    <div class="user-signup-btn">
+      <%= link_to "新規登録", new_user_registration_path, class: "post" %>
+    </div>
+  <% end %>
 </div>
 <div class="left-lists">
+  <div class="follow-num">
+    <p>フォロー○人</p>
+    <%#= link_to "#{@user.followeds.count} #{User.human_attribute_name("人をフォローしています（Following/フォロー中）")}", followings_user_path %>
+    <p>フォロワー○人</p>
+    <%#= link_to "#{@user.followings.count} #{User.human_attribute_name("人にフォローされています（Followed/フォロワー）")}", followeds_user_path %>
+  </div>
+  <div class="info">
+    <%= link_to "マイページ", "/users/#{current_user.id}" %>
+  </div>
+  <div class="info2">
+    <%= link_to "ルームを作成する", new_room_path %>
+  </div>
+  <div class="rooms">
+  <p>* 参加中のチャットルーム *</p>
   <% current_user.rooms.each do |room| %>
     <div class="room">
       <div class="room-name">
-        <h1>参加しているチャットルーム</h1>
         <%= link_to room.name, room_messages_path(room) %>
       </div>
     </div>
   <% end %>
+</div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,5 +35,10 @@
       </div>
     </header>
     <%= yield %>
+    <footer>
+      <p>
+        Copyright Go-Ya 2022.
+      </p>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
# What
・ログイン中のユーザー名
・フォロー/フォロワー数(こちらは場所を作っただけで表示は未実装です。)
・ユーザーログイン/ログアウト/新規登録ボタン
・ルーム作成ボタン
・参加中のルーム名一覧
以上の情報をサイドバーに追加しました。
# Why
ヘッダー情報をなくすため。

あまり綺麗な表示でなくて申し訳ないのですが、
一旦共有させていただきます。ご確認いただけますと幸いです。
ヘッダー部分を完全になくすのか、部品だけ無くして場所は残すのかはまた改めてご相談させてください。

https://gyazo.com/1b4ae5f7b7b9568aa1cb8864b519e211