### PR TITLE
生年月日情報追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,6 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :birthday])
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,7 +46,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:nickname, :email)
+    params.require(:user).permit(:nickname, :email, :birthday)
   end
 
   def set_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ApplicationRecord
   with_options presence: true do
-    validates :nickname
     validates :nickname, length: { maximum: 6 }
+    validates :birthday
   end
 
   PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -25,7 +25,7 @@
     <%= f.password_field :password_confirmation, autocomplete: "off" %>
   </div>
 
-  <%#div class="form-group">
+  <div class="form-group">
     <div class='form-text-wrap'>
       <label class="form-text">生年月日</label>
       <span class="indispensable">必須</span>
@@ -35,14 +35,15 @@
                   f.date_select(
                     :birthday,
                     class:'select-birth',
-                    id:"birthday",
+                    id:"birth-date",
                     use_month_numbers: true,
                     prompt:'--',
-                    start_year: 1930,
+                    start_year: 1950,
                     end_year: (Time.now.year - 5),
                     date_separator: '%s'),
                   "<p> 年 </p>", "<p> 月 </p>") + "<p> 日 </p>" %>
-  <%#/div %>
+    </div>
+  </div>
 
   <div class="actions">
     <%= f.submit "Sign up" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -6,6 +6,18 @@
       <%= form.text_field :nickname, placeholder: "Nickname" %>
       <h2>email</h2>
       <%= form.text_field :email, placeholder: "email" %>
+      <h2>birthday</h2>
+      <%= raw sprintf(
+                  form.date_select(
+                    :birthday,
+                    class:'select-birth',
+                    id:"birth-date",
+                    use_month_numbers: true,
+                    prompt:'--',
+                    start_year: 1950,
+                    end_year: (Time.now.year - 5),
+                    date_separator: '%s'),
+                  "<p> 年 </p>", "<p> 月 </p>") + "<p> 日 </p>" %>
       <h2></h2>
       <%= form.submit "編集" %>
     <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -6,10 +6,6 @@
       <%= form.text_field :nickname, placeholder: "Nickname" %>
       <h2>email</h2>
       <%= form.text_field :email, placeholder: "email" %>
-      <h2>password</h2>
-      <%= form.text_field :password, placeholder: "password" %>
-      <h2>password_confirmation</h2>
-      <%= form.text_field :password_confirmation, placeholder: "password_confirmation" %>
       <h2>birthday</h2>
       <%= raw sprintf(
                   form.date_select(

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -6,6 +6,10 @@
       <%= form.text_field :nickname, placeholder: "Nickname" %>
       <h2>email</h2>
       <%= form.text_field :email, placeholder: "email" %>
+      <h2>password</h2>
+      <%= form.text_field :password, placeholder: "password" %>
+      <h2>password_confirmation</h2>
+      <%= form.text_field :password_confirmation, placeholder: "password_confirmation" %>
       <h2>birthday</h2>
       <%= raw sprintf(
                   form.date_select(

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -29,7 +29,7 @@
 </div>
 
 <div class="info">
-  お誕生日：2023年01月25日
+  お誕生日：<%= @user.birthday %>
 </div>
 
 <div class='post'>

--- a/db/migrate/20220118032144_devise_create_users.rb
+++ b/db/migrate/20220118032144_devise_create_users.rb
@@ -7,6 +7,7 @@ class DeviseCreateUsers < ActiveRecord::Migration[6.0]
       t.string :email,              null: false, default: ""
       t.string :encrypted_password, null: false, default: ""
       t.string :nickname,           null: false
+      t.date :birthday,             null: false
 
       ## Recoverable
       t.string   :reset_password_token

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 2022_01_22_062918) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "nickname", null: false
+    t.date "birthday", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"


### PR DESCRIPTION
# What
ユーザー情報に生年月日を追加
# Why
ユーザー情報を充実させるため

新規登録画面
https://gyazo.com/feefc227b1b4512ed92b17d69ea2ea49
マイページ
https://gyazo.com/3370d6b28003d846748016e22e4c2aad

ps.パスワードの編集も一緒にできるようにしようと思ったのですが、
上手くいかなかったのでブランチ切り直して考えます。